### PR TITLE
docs: add cache api refresh in github stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Check out my **[Projects Hub](https://github.com/CodingWithJiro/Projects)** whic
   <img src="https://img.shields.io/github/followers/CodingWithJiro?label=Followers&style=flat-square&color=CC0022" alt="GitHub Followers"/>
 </p>
 
-![Elmar's GitHub Stats](https://github-readme-stats.vercel.app/api?username=CodingWithJiro&show_icons=true&title_color=FF0033&text_color=ffffff&icon_color=00E0FF&bg_color=0D0D0D)
+![Elmar's GitHub Stats](https://github-readme-stats.vercel.app/api?username=CodingWithJiro&show_icons=true&title_color=FF0033&text_color=ffffff&icon_color=00E0FF&bg_color=0D0D0D&cache_seconds=0)
 
-![Elmar's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=CodingWithJiro&layout=compact&langs_count=6&title_color=FF0033&text_color=FFFFFF&bg_color=0D0D0D)
+![Elmar's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=CodingWithJiro&layout=compact&langs_count=6&title_color=FF0033&text_color=FFFFFF&bg_color=0D0D0D&cache_seconds=0)
 
 # ⚙️ Learning Progress
 


### PR DESCRIPTION
## Description

I added a simple cache api refresh for my github stats in my github profile README.md

## Changes

- Added `&cache_seconds=0` at the end of the URL link for Elmar's GitHub Stats
- Added `&cache_seconds=0` at the end of the URL link for Elmar's Top Languages

## Notes for Reviewers

- Check if new code indeed refreshes and updates whenever a new repository is added a new commits are made
