### PR TITLE
docs: update github stats url and cache seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Check out my **[Projects Hub](https://github.com/CodingWithJiro/Projects)** whic
   <img src="https://img.shields.io/github/followers/CodingWithJiro?label=Followers&style=flat-square&color=CC0022" alt="GitHub Followers"/>
 </p>
 
-![Elmar's GitHub Stats](https://github-readme-stats.vercel.app/api?username=CodingWithJiro&show_icons=true&show_prs=true&title_color=FF0033&text_color=ffffff&icon_color=00E0FF&bg_color=0D0D0D&cache_seconds=0)
+![Elmar's GitHub Stats](https://github-readme-stats-codingwithjiro.vercel.app/api?username=CodingWithJiro&show_icons=true&show_prs=true&title_color=FF0033&text_color=ffffff&icon_color=00E0FF&bg_color=0D0D0D&cache_seconds=1800)
 
-![Elmar's Top Languages](https://github-readme-stats.vercel.app/api/top-langs/?username=CodingWithJiro&layout=compact&langs_count=6&title_color=FF0033&text_color=FFFFFF&bg_color=0D0D0D&cache_seconds=0)
+![Elmar's Top Languages](https://github-readme-stats-codingwithjiro.vercel.app/api/top-langs/?username=CodingWithJiro&layout=compact&langs_count=6&title_color=FF0033&text_color=FFFFFF&bg_color=0D0D0D&cache_seconds=1800)
 
 # ⚙️ Learning Progress
 


### PR DESCRIPTION
## Description

Updated the URL for my GitHub stats and cache seconds to 1800 or 30mins.

## Changes

- Used a self-hosted URL instead (https://github-readme-stats-codingwithjiro.vercel.app)
- Made sure the API calls have 30mins intervals

## Notes for Reviewers

- Merge for better and frequent GitHub stats update
